### PR TITLE
Simplify suberrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The type generation process is recursive, traveling down through any nested `Inp
 |-------------|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `code`      | `int` &vert; `<field-name>ErrorCode` | This will resolve to `0` for a valid field, otherwise `1`. If `errorCodes` were provided, then this will be a custom generated Enum type.             |
 | `msg`       | `string`                      | A plain, natural language description of the error.                                                                                                   |
-| `suberrors` | `<field-name>_Suberrors`      | If your field has a complex type (eg. `InputObjectType` or `ListOfType`), then a `suberrors` field will be added with its own custom, generated type. |
+| `suberrors` | `<field-name>_Suberrors`      | A `suberrors` field will be added to a generated field of type `InputObjectType` if any of the following are true: <ol><li>It is the root node</li><li>The field has a `validate` method</li><li>The `InputObjectType` is wrapped in a `ListOfType`</li></ol> 
 
 The top-level `<field-name>ResultType` will have a few additional fields:
 

--- a/examples/05-list-of-input-object-validation/index.php
+++ b/examples/05-list-of-input-object-validation/index.php
@@ -62,15 +62,6 @@ try {
                 ],
                 'args' => [
                     'authors' => [
-//                        'errorCodes' => [
-//                            'notEnoughInfo'
-//                        ],
-//                        'validate' => function(array $author) {
-//                            if(empty($author['firstName']) && empty($author['latName'])) {
-//                                return ['notEnoughInfo', 'Minimally, you must enter a first or last name'];
-//                            }
-//                            return 0;
-//                        },
                         'type' => Type::listOf(new InputObjectType([
                             'name' => 'AuthorInput',
                             'fields' => [

--- a/examples/05-list-of-input-object-validation/index.php
+++ b/examples/05-list-of-input-object-validation/index.php
@@ -62,15 +62,15 @@ try {
                 ],
                 'args' => [
                     'authors' => [
-                        'errorCodes' => [
-                            'notEnoughInfo'
-                        ],
-                        'validate' => function(array $author) {
-                            if(empty($author['firstName']) && empty($author['latName'])) {
-                                return ['notEnoughInfo', 'Minimally, you must enter a first or last name'];
-                            }
-                            return 0;
-                        },
+//                        'errorCodes' => [
+//                            'notEnoughInfo'
+//                        ],
+//                        'validate' => function(array $author) {
+//                            if(empty($author['firstName']) && empty($author['latName'])) {
+//                                return ['notEnoughInfo', 'Minimally, you must enter a first or last name'];
+//                            }
+//                            return 0;
+//                        },
                         'type' => Type::listOf(new InputObjectType([
                             'name' => 'AuthorInput',
                             'fields' => [

--- a/src/Type/Definition/UserErrorsType.php
+++ b/src/Type/Definition/UserErrorsType.php
@@ -88,11 +88,11 @@ class UserErrorsType extends ObjectType
                     },
                 ];
 
-                $createSubErrors ? $fields[$key] = $errType : $finalFields[$key] = $errType;
+                $fields[$key] = $errType;
             }
         }
 
-        if (!empty($fields)) {
+        if ($createSubErrors && count($fields)) {
             /**
              * errors property
              */
@@ -107,6 +107,9 @@ class UserErrorsType extends ObjectType
                     return $value[static::SUBERRORS_NAME] ?? null;
                 },
             ];
+        }
+        else {
+            $finalFields += $fields;
         }
     }
 

--- a/src/Type/Definition/UserErrorsType.php
+++ b/src/Type/Definition/UserErrorsType.php
@@ -83,7 +83,7 @@ class UserErrorsType extends ObjectType
                     'description' => 'Error for ' . $key,
                     'type' => $field->type instanceof ListOfType ? Type::listOf($newType) : $newType,
                     'resolve' => static function ($value) use ($key) {
-                        return $value[$key];
+                        return $value[$key] ?? null;
                     },
                 ];
             }

--- a/src/Type/Definition/UserErrorsType.php
+++ b/src/Type/Definition/UserErrorsType.php
@@ -42,7 +42,7 @@ class UserErrorsType extends ObjectType
         }
 
         if ($isParentList) {
-            $this->_addPath($finalFields);
+            $this->_addPathField($finalFields);
         }
 
         parent::__construct([
@@ -54,7 +54,8 @@ class UserErrorsType extends ObjectType
 
     protected function _getType($config) {
         $type = $config['type'];
-        if ($type instanceof NonNull || $type instanceof ListOfType) {
+        
+        if ($type instanceof WrappingType) {
             $type = $type->getWrappedType(true);
         }
         return $type;
@@ -146,7 +147,7 @@ class UserErrorsType extends ObjectType
         }
     }
 
-    protected function _addPath(&$finalFields) {
+    protected function _addPathField(&$finalFields) {
         if (!empty($finalFields['code']) || !empty($finalFields['suberrors'])) {
             $finalFields['path'] = [
                 'type' => Type::listOf(Type::int()),
@@ -177,8 +178,6 @@ class UserErrorsType extends ObjectType
      * @param string   $name
      *
      * @return static|null
-     *
-     * @throws Exception
      */
     public static function create(array $config, array $path, bool $isParentList = false, string $name = '') : ?self
     {

--- a/src/Type/Definition/UserErrorsType.php
+++ b/src/Type/Definition/UserErrorsType.php
@@ -84,7 +84,7 @@ class UserErrorsType extends ObjectType
                     'description' => 'Error for ' . $key,
                     'type' => $field->type instanceof ListOfType ? Type::listOf($newType) : $newType,
                     'resolve' => static function ($value) use ($key) {
-                        return $value[$key] ?? null;
+                        return $value[$key];
                     },
                 ];
 

--- a/src/Type/Definition/UserErrorsType.php
+++ b/src/Type/Definition/UserErrorsType.php
@@ -38,11 +38,11 @@ class UserErrorsType extends ObjectType
 
         $type = $this->_getType($config);
         if ($type instanceof InputObjectType) {
-            $this->_buildInputObjectType($type, $config, $path, $finalFields);
+            $this->_buildInputObjectType($type, $config, $path, $finalFields, $isParentList);
         }
 
         if ($isParentList) {
-            $this->_addSuberrorCodes($finalFields);
+            $this->_addPath($finalFields);
         }
 
         parent::__construct([
@@ -60,9 +60,8 @@ class UserErrorsType extends ObjectType
         return $type;
     }
 
-    protected function _buildInputObjectType(InputObjectType $type, $config, $path, &$finalFields) {
-
-        $createSubErrors = !empty($config['validate']);
+    protected function _buildInputObjectType(InputObjectType $type, $config, $path, &$finalFields, $isParentList) {
+        $createSubErrors = !empty($config['validate']) || !empty($config['isRoot']) || $isParentList;
         $fields = [];
         foreach ($type->getFields() as $key => $field) {
             $fieldType = $this->_getType($field->config);
@@ -147,8 +146,8 @@ class UserErrorsType extends ObjectType
         }
     }
 
-    protected function _addSuberrorCodes(&$finalFields) {
-        if (isset($finalFields['code'])) {
+    protected function _addPath(&$finalFields) {
+        if (!empty($finalFields['code']) || !empty($finalFields['suberrors'])) {
             $finalFields['path'] = [
                 'type' => Type::listOf(Type::int()),
                 'description' => 'A path describing this items\'s location in the nested array',

--- a/src/Type/Definition/UserErrorsType.php
+++ b/src/Type/Definition/UserErrorsType.php
@@ -89,12 +89,7 @@ class UserErrorsType extends ObjectType
                 },
             ];
 
-            if($createSubErrors) {
-                $fields[$key] = $errType;
-            }
-            else {
-                $finalFields[$key] = $errType;
-            }
+            $createSubErrors ? $fields[$key] = $errType : $finalFields[$key] = $errType;
         }
 
         if ($createSubErrors && !empty($fields)) {

--- a/src/Type/Definition/UserErrorsType.php
+++ b/src/Type/Definition/UserErrorsType.php
@@ -16,7 +16,7 @@ use function ucfirst;
 
 class UserErrorsType extends ObjectType
 {
-    protected const ERROR_NAME = 'suberrors';
+    public const SUBERRORS_NAME = 'suberrors';
     protected const CODE_NAME = 'code';
     protected const MESSAGE_NAME = 'msg';
 
@@ -101,7 +101,7 @@ class UserErrorsType extends ObjectType
             /**
              * errors property
              */
-            $finalFields[static::ERROR_NAME] = [
+            $finalFields[static::SUBERRORS_NAME] = [
                 'type' => $this->_set(new ObjectType([
                     'name' => $this->_nameFromPath(array_merge($path, ['fieldErrors'])),
                     'description' => 'User Error',
@@ -109,7 +109,7 @@ class UserErrorsType extends ObjectType
                 ]), $config),
                 'description' => 'Validation errors for ' . ucfirst($path[count($path)-1]),
                 'resolve' => static function (array $value) {
-                    return $value['errors'] ?? null;
+                    return $value[static::SUBERRORS_NAME] ?? null;
                 },
             ];
         }

--- a/src/Type/Definition/UserErrorsType.php
+++ b/src/Type/Definition/UserErrorsType.php
@@ -61,8 +61,12 @@ class UserErrorsType extends ObjectType
         return $type;
     }
 
+    static public function needSuberrors(array $config, bool $isParentList) : bool {
+        return !empty($config['validate']) || !empty($config['isRoot']) || $isParentList;
+    }
+
     protected function _buildInputObjectType(InputObjectType $type, $config, $path, &$finalFields, $isParentList) {
-        $createSubErrors = !empty($config['validate']) || !empty($config['isRoot']) || $isParentList;
+        $createSubErrors = static::needSuberrors($config, $isParentList);
         $fields = [];
         foreach ($type->getFields() as $key => $field) {
             $fieldType = $this->_getType($field->config);

--- a/src/Type/Definition/UserErrorsType.php
+++ b/src/Type/Definition/UserErrorsType.php
@@ -61,6 +61,8 @@ class UserErrorsType extends ObjectType
     }
 
     protected function _buildInputObjectType(InputObjectType $type, $config, $path, &$finalFields) {
+
+        $createSubErrors = !empty($config['validate']);
         $fields = [];
         foreach ($type->getFields() as $key => $field) {
             $fieldType = $this->_getType($field->config);
@@ -79,16 +81,23 @@ class UserErrorsType extends ObjectType
                 continue;
             }
 
-            $fields[$key] = [
+            $errType = [
                 'description' => 'Error for ' . $key,
                 'type' => $field->type instanceof ListOfType ? Type::listOf($newType) : $newType,
                 'resolve' => static function ($value) use ($key) {
                     return $value[$key] ?? null;
                 },
             ];
+
+            if($createSubErrors) {
+                $fields[$key] = $errType;
+            }
+            else {
+                $finalFields[$key] = $errType;
+            }
         }
 
-        if ($fields) {
+        if ($createSubErrors && !empty($fields)) {
             /**
              * errors property
              */

--- a/src/Type/Definition/UserErrorsType.php
+++ b/src/Type/Definition/UserErrorsType.php
@@ -195,6 +195,11 @@ class UserErrorsType extends ObjectType
             }
             return $userErrorType;
         }
+
+        if(count($path) == 1) {
+            throw new Exception("You must specify at least one 'validate' callback somewhere");
+        }
+
         return null;
     }
 

--- a/src/Type/Definition/ValidatedFieldDefinition.php
+++ b/src/Type/Definition/ValidatedFieldDefinition.php
@@ -120,11 +120,7 @@ class ValidatedFieldDefinition extends FieldDefinition
                         'type' => $wrappedType
                     ], $subValue, $config['type'] instanceof ListOfType);
 
-                    if(isset($err['errors'])) {
-                        $i = 5;
-                    }
-
-                    $err = $err['errors'] ?? null;
+//                    $err = $err[UserErrorsType::SUBERRORS_NAME] ?? $err;
                 }
 
                 if ($err) {
@@ -172,11 +168,17 @@ class ValidatedFieldDefinition extends FieldDefinition
             try {
                 $this->_validateItems($config, $value, [0], $config['validate']);
             } catch (ValidateItemsError $e) {
-                $i = 5;
-                $res[] = [
-                    'error' => $e->error,
-                    'path' => $e->path,
-                ];
+                if(isset($e->error['suberrors'])) {
+                    $err = $e->error;
+                }
+                else {
+                    $err = [
+                        'error' => $e->error,
+                    ];
+                }
+                $err['path'] = $e->path;
+                $res[] = $err;
+
             }
         }
     }

--- a/src/Type/Definition/ValidatedFieldDefinition.php
+++ b/src/Type/Definition/ValidatedFieldDefinition.php
@@ -197,7 +197,7 @@ class ValidatedFieldDefinition extends FieldDefinition
     }
 
     protected function _validateInputObjectFields($type, array $config, $value, &$res, $isParentList = false) {
-        $createSubErrors = !empty($config['validate']) || !empty($config['isRoot']) || $isParentList;
+        $createSubErrors = UserErrorsType::needSuberrors($config, $isParentList);
 
         $fields = $type->getFields();
         if (is_array($value)) {

--- a/src/Type/Definition/ValidatedFieldDefinition.php
+++ b/src/Type/Definition/ValidatedFieldDefinition.php
@@ -34,12 +34,6 @@ class ValidatedFieldDefinition extends FieldDefinition
         $validFieldName = $config['validName'] ?? 'valid';
         $resultFieldName = $config['resultName'] ?? 'result';
 
-        foreach(array_keys($config['args']) as $key) {
-            if($key == $validFieldName || $key == $resultFieldName) {
-                throw new \Exception("'$key' is a reserved field name at the root definition.");
-            }
-        }
-
         $type = UserErrorsType::create([
             'errorCodes' => $config['errorCodes'] ?? null,
             'isRoot' => true,

--- a/src/Type/Definition/ValidatedFieldDefinition.php
+++ b/src/Type/Definition/ValidatedFieldDefinition.php
@@ -206,11 +206,7 @@ class ValidatedFieldDefinition extends FieldDefinition
                 $error = $this->_validate($config, $subValue);
 
                 if($error) {
-                    if ($createSubErrors) {
-                        $res[UserErrorsType::SUBERRORS_NAME][$key] = $error;
-                    } else {
-                        $res[$key] = $error;
-                    }
+                    $createSubErrors ? $res[UserErrorsType::SUBERRORS_NAME][$key] = $error : $res[$key] = $error;
                 }
             }
         }

--- a/src/Type/Definition/ValidatedFieldDefinition.php
+++ b/src/Type/Definition/ValidatedFieldDefinition.php
@@ -118,7 +118,7 @@ class ValidatedFieldDefinition extends FieldDefinition
                     $wrappedType = $config['type']->getWrappedType(true);
                     $err = $this->_validate([
                         'type' => $wrappedType
-                    ], $subValue);
+                    ], $subValue, $config['type'] instanceof ListOfType);
 
                     if(isset($err['errors'])) {
                         $i = 5;
@@ -139,7 +139,7 @@ class ValidatedFieldDefinition extends FieldDefinition
      * @param mixed $value
      * @return mixed[]
      */
-    protected function _validate(array $arg, $value) : array
+    protected function _validate(array $arg, $value, bool $isParentList = false) : array
     {
         $res = [];
 
@@ -155,7 +155,7 @@ class ValidatedFieldDefinition extends FieldDefinition
                 break;
 
             case $type instanceof InputObjectType:
-                $this->_validateInputObject($arg, $value, $res);
+                $this->_validateInputObject($arg, $value, $res, $isParentList);
                 break;
 
             default:
@@ -181,7 +181,7 @@ class ValidatedFieldDefinition extends FieldDefinition
         }
     }
 
-    protected function _validateInputObject($arg, $value, &$res) {
+    protected function _validateInputObject($arg, $value, &$res, bool $isParentList) {
         $type = $arg['type'];
         if (isset($arg['validate'])) {
             $err = $arg['validate']($value) ?? [];
@@ -191,7 +191,7 @@ class ValidatedFieldDefinition extends FieldDefinition
             }
         }
 
-        $this->_validateInputObjectFields($type, $arg, $value, $res);
+        $this->_validateInputObjectFields($type, $arg, $value, $res, $isParentList);
     }
 
     protected function _validateInputObjectFields($type, array $config, $value, &$res, $isParentList = false) {

--- a/src/Type/Definition/ValidatedFieldDefinition.php
+++ b/src/Type/Definition/ValidatedFieldDefinition.php
@@ -42,6 +42,7 @@ class ValidatedFieldDefinition extends FieldDefinition
 
         $type = UserErrorsType::create([
             'errorCodes' => $config['errorCodes'] ?? null,
+            'isRoot' => true,
             'fields' => [
                 $resultFieldName => [
                     'type' => $config['type'],

--- a/tests/Type/ErrorCodeTypeGenerationTest.php
+++ b/tests/Type/ErrorCodeTypeGenerationTest.php
@@ -95,7 +95,7 @@ final class ErrorCodeTypeGenerationTest extends TestCase
             },
         ], ['updateBook']);
 
-        self::assertCount(3, array_keys($types));
+        self::assertCount(2, array_keys($types));
         self::assertTrue(isset($types['UpdateBook_AuthorIdErrorCode']));
         self::assertEquals(
             SchemaPrinter::printType($types['UpdateBook_AuthorIdErrorCode']),

--- a/tests/Type/FieldDefinitionTest.php
+++ b/tests/Type/FieldDefinitionTest.php
@@ -29,4 +29,42 @@ abstract class FieldDefinitionTest extends TestCase
 
         self::assertEquals(Utils::nowdoc($expected), SchemaPrinter::doPrint(new Schema(['mutation' => $mutation])));
     }
+
+    protected function _checkTypes($field, array $expectedMap): void {
+        $mutation = new ObjectType([
+            'name' => 'Mutation',
+            'fields' => static function () use($field) {
+                return [
+                    $field->name => $field,
+                ];
+            },
+        ]);
+
+        $schema = new Schema(['mutation' => $mutation]);
+
+        $types = $schema->getTypeMap();
+
+        $types = array_filter($types, function($type) {
+            return ! Type::isBuiltInType($type);
+        });
+
+
+        $t = array_map(function($type) {
+            $type->description = null;
+            return Utils::toNowDoc(SchemaPrinter::printType($type), 8);
+        }, $types);
+
+        $lines = preg_split('/\\n/', Utils::varExport($t, true));
+
+        $numLines = count($lines);
+        for ($i = 0; $i < $numLines; $i++) {
+            $lines[$i] = str_repeat(" ", 12) .$lines[$i];
+        }
+
+        file_put_contents("D:/Users/Shmax/schema.php", implode("\n", $lines));
+
+        foreach($expectedMap as $typeName => $expected) {
+            self::assertEquals(Utils::nowdoc($expected), SchemaPrinter::printType($types[$typeName]));
+        }
+    }
 }

--- a/tests/Type/FieldDefinitionTest.php
+++ b/tests/Type/FieldDefinitionTest.php
@@ -17,6 +17,7 @@ use function count;
 
 abstract class FieldDefinitionTest extends TestCase
 {
+//    protected $outputPath = 'tmp/';
     protected function _checkSchema(ValidatedFieldDefinition $field, $expected): void {
         $mutation = new ObjectType([
             'name' => 'Mutation',
@@ -49,19 +50,20 @@ abstract class FieldDefinitionTest extends TestCase
         });
 
 
-        $t = array_map(function($type) {
+        $typeMap = array_map(function($type) {
             $type->description = null;
             return Utils::toNowDoc(SchemaPrinter::printType($type), 8);
         }, $types);
 
-        $lines = preg_split('/\\n/', Utils::varExport($t, true));
+        if(!empty($this->outputPath)) {
+            $lines = preg_split('/\\n/', Utils::varExport($typeMap, true));
+            $numLines = count($lines);
+            for ($i = 0; $i < $numLines; $i++) {
+                $lines[$i] = str_repeat(" ", 12) . $lines[$i];
+            }
 
-        $numLines = count($lines);
-        for ($i = 0; $i < $numLines; $i++) {
-            $lines[$i] = str_repeat(" ", 12) .$lines[$i];
+            file_put_contents($this->outputPath . 'schema.php', implode("\n", $lines));
         }
-
-        file_put_contents("D:/Users/Shmax/schema.php", implode("\n", $lines));
 
         foreach($expectedMap as $typeName => $expected) {
             self::assertEquals(Utils::nowdoc($expected), SchemaPrinter::printType($types[$typeName]));

--- a/tests/Type/FieldDefinitionTest.php
+++ b/tests/Type/FieldDefinitionTest.php
@@ -53,7 +53,7 @@ abstract class FieldDefinitionTest extends TestCase
             $args
         );
 
-        static::assertEquals($res->errors, [], "There should be no errors in your query");
+        static::assertEquals([], $res->errors, "There should be no errors in your query");
         static::assertEquals($expected, $res->data[$field->name]);
 
     }

--- a/tests/Type/UserErrorsType/BasicTest.php
+++ b/tests/Type/UserErrorsType/BasicTest.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace GraphQL\Tests\Type\UserErrorsType;
 
+use GraphQL\Tests\Type\FieldDefinitionTest;
 use GraphQL\Tests\Utils;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UserErrorsType;
+use GraphQL\Type\Definition\ValidatedFieldDefinition;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\SchemaPrinter;
 use PHPUnit\Framework\TestCase;
 
-final class BasicTest extends TestCase
+final class BasicTest extends FieldDefinitionTest
 {
     public function testNoValidationOnSelf(): void
     {
@@ -40,6 +42,112 @@ final class BasicTest extends TestCase
                 return $value ? 0 : 1;
             },
         ], ['upsertSku']);
+    }
+
+    public function testArgCollisionWithResultName(): void
+    {
+        $this->expectExceptionMessage("'result' is a reserved field name at the root definition.");
+        new ValidatedFieldDefinition([
+            'type' => Type::boolean(),
+            'name' => 'updateBook',
+            'validate' => static function() {},
+            'args' => [
+                'result' => [
+
+                ]
+            ],
+            'resolve' => static function (array $data) : bool {
+                return !empty($data);
+            },
+        ]);
+    }
+
+    public function testArgCollisionWithValidName(): void
+    {
+        $this->expectExceptionMessage("'valid' is a reserved field name at the root definition.");
+        new ValidatedFieldDefinition([
+            'type' => Type::boolean(),
+            'name' => 'updateBook',
+            'validate' => static function() {},
+            'args' => [
+                'valid' => [
+
+                ]
+            ],
+            'resolve' => static function (array $data) : bool {
+                return !empty($data);
+            },
+        ]);
+    }
+
+    public function testRenameResultsField(): void
+    {
+        $this->_checkSchema(new ValidatedFieldDefinition([
+            'type' => Type::boolean(),
+            'name' => 'updateBook',
+            'resultName' => '_result',
+            'validate' => static function() {},
+            'args' => [],
+            'resolve' => static function (array $data) : bool {
+                return !empty($data);
+            },
+        ]),
+        '
+            type Mutation {
+              updateBook: UpdateBookResult
+            }
+            
+            """User errors for UpdateBook"""
+            type UpdateBookResult {
+              """The payload, if any"""
+              _result: Boolean
+            
+              """Whether all validation passed. True for yes, false for no."""
+              valid: Boolean!
+            
+              """A numeric error code. 0 on success, non-zero on failure."""
+              code: Int
+            
+              """An error message."""
+              msg: String
+            }
+
+        ');
+    }
+
+    public function testRenameValidField(): void
+    {
+        $this->_checkSchema(new ValidatedFieldDefinition([
+            'type' => Type::boolean(),
+            'name' => 'updateBook',
+            'validName' => '_valid',
+            'validate' => static function() {},
+            'args' => [],
+            'resolve' => static function (array $data) : bool {
+                return !empty($data);
+            },
+        ]),
+            '
+            type Mutation {
+              updateBook: UpdateBookResult
+            }
+            
+            """User errors for UpdateBook"""
+            type UpdateBookResult {
+              """The payload, if any"""
+              result: Boolean
+            
+              """Whether all validation passed. True for yes, false for no."""
+              _valid: Boolean!
+            
+              """A numeric error code. 0 on success, non-zero on failure."""
+              code: Int
+            
+              """An error message."""
+              msg: String
+            }
+
+        ');
     }
 
     public function testValidationWithNoErrorCodes(): void

--- a/tests/Type/UserErrorsType/BasicTest.php
+++ b/tests/Type/UserErrorsType/BasicTest.php
@@ -6,6 +6,7 @@ namespace GraphQL\Tests\Type\UserErrorsType;
 
 use GraphQL\Tests\Type\FieldDefinitionTest;
 use GraphQL\Tests\Utils;
+use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UserErrorsType;
 use GraphQL\Type\Definition\ValidatedFieldDefinition;
@@ -148,6 +149,28 @@ final class BasicTest extends FieldDefinitionTest
             }
 
         ');
+    }
+
+    public function testNoValidateCallbacks(): void
+    {
+        $this->expectExceptionMessage("You must specify at least one 'validate' callback somewhere");
+        UserErrorsType::create([
+            'type' => new InputObjectType([
+                'name' => 'book',
+                'fields' => [
+                    'author' => [
+                        'type' => new InputObjectType([
+                            'name' => 'address',
+                            'fields' => [
+                                'zip' => [
+                                    'type' => Type::string()
+                                ]
+                            ]
+                        ])
+                    ]
+                ],
+            ]),
+        ], ['updateBook']);
     }
 
     public function testValidationWithNoErrorCodes(): void

--- a/tests/Type/UserErrorsType/BasicTest.php
+++ b/tests/Type/UserErrorsType/BasicTest.php
@@ -45,42 +45,6 @@ final class BasicTest extends FieldDefinitionTest
         ], ['upsertSku']);
     }
 
-    public function testArgCollisionWithResultName(): void
-    {
-        $this->expectExceptionMessage("'result' is a reserved field name at the root definition.");
-        new ValidatedFieldDefinition([
-            'type' => Type::boolean(),
-            'name' => 'updateBook',
-            'validate' => static function() {},
-            'args' => [
-                'result' => [
-
-                ]
-            ],
-            'resolve' => static function (array $data) : bool {
-                return !empty($data);
-            },
-        ]);
-    }
-
-    public function testArgCollisionWithValidName(): void
-    {
-        $this->expectExceptionMessage("'valid' is a reserved field name at the root definition.");
-        new ValidatedFieldDefinition([
-            'type' => Type::boolean(),
-            'name' => 'updateBook',
-            'validate' => static function() {},
-            'args' => [
-                'valid' => [
-
-                ]
-            ],
-            'resolve' => static function (array $data) : bool {
-                return !empty($data);
-            },
-        ]);
-    }
-
     public function testRenameResultsField(): void
     {
         $this->_checkSchema(new ValidatedFieldDefinition([

--- a/tests/Type/UserErrorsType/InputObjectTest.php
+++ b/tests/Type/UserErrorsType/InputObjectTest.php
@@ -23,119 +23,167 @@ final class InputObjectTest extends FieldDefinitionTest
                 'fields' => [
                     'authorId' => [
                         'errorCodes' => ['unknownAuthor'],
-                        'type' => Type::id(),
-                        'description' => 'An author Id',
+                        'type' => Type::id()
                     ],
                 ],
             ]),
         ], ['updateBook']);
     }
 
-    public function testValidateSelfAndValidateFields(): void
+    public function testValidateOnFieldsButNotOnSelf(): void
     {
-        $this->_checkSchema(new ValidatedFieldDefinition([
-            'type' => Type::boolean(),
-            'name' => 'updateBook',
-            'args' => [
-                'book' => [
-                    'validate' => static function() {},
-                    'type' => new InputObjectType([
-                        'name' => 'book',
-                        'fields' => [
-                            'title' => [
-                                'type' => Type::string(),
-                                'validate' => static function() { return 0; }
-                            ],
-                            'authorId' => [
-                                'errorCodes' => ['unknownAuthor'],
-                                'validate' => static function (int $authorId) {
-                                    return $authorId ? 0 : 1;
-                                },
-                                'type' => Type::id(),
-                                'description' => 'An author Id',
-                            ],
+        $this->_checkTypes(
+            UserErrorsType::create([
+                'type' => new InputObjectType([
+                    'name' => 'book',
+                    'fields' => [
+                        'title' => [
+                            'type' => Type::string(),
+                            'validate' => static function() { return 0; }
                         ],
-                    ])
-                ],
-            ],
-            'resolve' => static function (array $data) : bool {
-                return !empty($data);
-            },
-        ]),
-        '
-            type Mutation {
-              updateBook(book: book): UpdateBookResult
-            }
-            
-            """User errors for UpdateBook"""
-            type UpdateBookResult {
-              """The payload, if any"""
-              result: Boolean
-            
-              """Whether all validation passed. True for yes, false for no."""
-              valid: Boolean!
-            
-              """Validation errors for UpdateBook"""
-              suberrors: UpdateBook_FieldErrors
-            }
-            
-            """User errors for Book"""
-            type UpdateBook_BookError {
-              """A numeric error code. 0 on success, non-zero on failure."""
-              code: Int
-            
-              """An error message."""
-              msg: String
-            
-              """Validation errors for Book"""
-              suberrors: UpdateBook_Book_FieldErrors
-            }
-            
-            """User errors for AuthorId"""
-            type UpdateBook_Book_AuthorIdError {
-              """An error code"""
-              code: UpdateBook_Book_AuthorIdErrorCode
-            
-              """A natural language description of the issue"""
-              msg: String
-            }
-            
-            """Error code"""
-            enum UpdateBook_Book_AuthorIdErrorCode {
-              unknownAuthor
-            }
-            
-            """User Error"""
-            type UpdateBook_Book_FieldErrors {
-              """Error for title"""
-              title: UpdateBook_Book_TitleError
-            
-              """Error for authorId"""
-              authorId: UpdateBook_Book_AuthorIdError
-            }
-            
-            """User errors for Title"""
-            type UpdateBook_Book_TitleError {
-              """A numeric error code. 0 on success, non-zero on failure."""
-              code: Int
-            
-              """An error message."""
-              msg: String
-            }
-            
-            """User Error"""
-            type UpdateBook_FieldErrors {
-              """Error for book"""
-              book: UpdateBook_BookError
-            }
-            
-            input book {
-              title: String
-            
-              """An author Id"""
-              authorId: ID
-            }
+                        'authorId' => [
+                            'errorCodes' => ['unknownAuthor'],
+                            'validate' => static function (int $authorId) {
+                                return $authorId ? 0 : 1;
+                            },
+                            'type' => Type::id()
+                        ],
+                    ],
+                ]),
+            ], ['updateBook']),
+            [
+                'Mutation' => '
+                    type Mutation {
+                      UpdateBookError: UpdateBookError
+                    }
+              ',
+                'UpdateBookError' => '
+                    type UpdateBookError {
+                      """Error for title"""
+                      title: UpdateBook_TitleError
+                    
+                      """Error for authorId"""
+                      authorId: UpdateBook_AuthorIdError
+                    }
+              ',
+                'UpdateBook_TitleError' => '
+                    type UpdateBook_TitleError {
+                      """A numeric error code. 0 on success, non-zero on failure."""
+                      code: Int
+                    
+                      """An error message."""
+                      msg: String
+                    }
+              ',
+                'UpdateBook_AuthorIdError' => '
+                    type UpdateBook_AuthorIdError {
+                      """An error code"""
+                      code: UpdateBook_AuthorIdErrorCode
+                    
+                      """A natural language description of the issue"""
+                      msg: String
+                    }
+              ',
+                'UpdateBook_AuthorIdErrorCode' => '
+                    enum UpdateBook_AuthorIdErrorCode {
+                      unknownAuthor
+                    }
+              ',
+            ]
+         );
+    }
 
-        ');
+    public function testValidateOnSelfButNotOnFields(): void
+    {
+        $this->_checkTypes(
+            UserErrorsType::create([
+                'validate' => static function() {},
+                'type' => new InputObjectType([
+                    'name' => 'book',
+                    'fields' => [
+                        'title' => [
+                            'type' => Type::string()
+                        ],
+                        'authorId' => [
+                            'type' => Type::id()
+                        ],
+                    ],
+                ]),
+            ], ['updateBook']),
+            [
+                'UpdateBookError' => '
+                    type UpdateBookError {
+                      """A numeric error code. 0 on success, non-zero on failure."""
+                      code: Int
+                    
+                      """An error message."""
+                      msg: String
+                    }
+              ',
+            ]
+        );
+    }
+
+    public function testValidateOnSelfAndOnFields(): void
+    {
+        $this->_checkTypes(
+            UserErrorsType::create([
+                'validate' => static function() {},
+                'type' => new InputObjectType([
+                    'name' => 'book',
+                    'fields' => [
+                        'title' => [
+                            'validate' => static function() {},
+                            'type' => Type::string()
+                        ],
+                        'authorId' => [
+                            'validate' => static function() {},
+                            'type' => Type::id()
+                        ],
+                    ],
+                ]),
+            ], ['updateBook']),
+            [
+                'UpdateBookError' => '
+                    type UpdateBookError {
+                      """A numeric error code. 0 on success, non-zero on failure."""
+                      code: Int
+                    
+                      """An error message."""
+                      msg: String
+                    
+                      """Validation errors for UpdateBook"""
+                      suberrors: UpdateBook_FieldErrors
+                    }
+                ',
+                'UpdateBook_FieldErrors' => '
+                    type UpdateBook_FieldErrors {
+                      """Error for title"""
+                      title: UpdateBook_TitleError
+                    
+                      """Error for authorId"""
+                      authorId: UpdateBook_AuthorIdError
+                    }
+                ',
+                'UpdateBook_TitleError' => '
+                    type UpdateBook_TitleError {
+                      """A numeric error code. 0 on success, non-zero on failure."""
+                      code: Int
+                    
+                      """An error message."""
+                      msg: String
+                    }
+                ',
+                'UpdateBook_AuthorIdError' => '
+                    type UpdateBook_AuthorIdError {
+                      """A numeric error code. 0 on success, non-zero on failure."""
+                      code: Int
+                    
+                      """An error message."""
+                      msg: String
+                    }
+                ',
+            ]
+        );
     }
 }

--- a/tests/Type/UserErrorsType/InputObjectTest.php
+++ b/tests/Type/UserErrorsType/InputObjectTest.php
@@ -36,11 +36,10 @@ final class InputObjectTest extends FieldDefinitionTest
         $this->_checkSchema(new ValidatedFieldDefinition([
             'type' => Type::boolean(),
             'name' => 'updateBook',
+            'validName' => '_valid',
+            'resultName' => '_result',
             'args' => [
                 'book' => [
-                    'validate' => static function($book) {
-                        return empty($book) ? 1 : 0;
-                    },
                     'type' => new InputObjectType([
                         'name' => 'book',
                         'fields' => [

--- a/tests/Type/UserErrorsType/InputObjectTest.php
+++ b/tests/Type/UserErrorsType/InputObjectTest.php
@@ -36,10 +36,9 @@ final class InputObjectTest extends FieldDefinitionTest
         $this->_checkSchema(new ValidatedFieldDefinition([
             'type' => Type::boolean(),
             'name' => 'updateBook',
-            'validName' => '_valid',
-            'resultName' => '_result',
             'args' => [
                 'book' => [
+                    'validate' => static function() {},
                     'type' => new InputObjectType([
                         'name' => 'book',
                         'fields' => [
@@ -71,22 +70,25 @@ final class InputObjectTest extends FieldDefinitionTest
             """User errors for UpdateBook"""
             type UpdateBookResult {
               """The payload, if any"""
-              _result: Boolean
+              result: Boolean
             
               """Whether all validation passed. True for yes, false for no."""
-              _valid: Boolean!
+              valid: Boolean!
             
-              """Error for book"""
-              book: UpdateBook_BookError
+              """Validation errors for UpdateBook"""
+              suberrors: UpdateBook_FieldErrors
             }
             
             """User errors for Book"""
             type UpdateBook_BookError {
-              """Error for title"""
-              title: UpdateBook_Book_TitleError
+              """A numeric error code. 0 on success, non-zero on failure."""
+              code: Int
             
-              """Error for authorId"""
-              authorId: UpdateBook_Book_AuthorIdError
+              """An error message."""
+              msg: String
+            
+              """Validation errors for Book"""
+              suberrors: UpdateBook_Book_FieldErrors
             }
             
             """User errors for AuthorId"""
@@ -103,6 +105,15 @@ final class InputObjectTest extends FieldDefinitionTest
               unknownAuthor
             }
             
+            """User Error"""
+            type UpdateBook_Book_FieldErrors {
+              """Error for title"""
+              title: UpdateBook_Book_TitleError
+            
+              """Error for authorId"""
+              authorId: UpdateBook_Book_AuthorIdError
+            }
+            
             """User errors for Title"""
             type UpdateBook_Book_TitleError {
               """A numeric error code. 0 on success, non-zero on failure."""
@@ -110,6 +121,12 @@ final class InputObjectTest extends FieldDefinitionTest
             
               """An error message."""
               msg: String
+            }
+            
+            """User Error"""
+            type UpdateBook_FieldErrors {
+              """Error for book"""
+              book: UpdateBook_BookError
             }
             
             input book {

--- a/tests/Type/UserErrorsType/InputObjectTest.php
+++ b/tests/Type/UserErrorsType/InputObjectTest.php
@@ -71,25 +71,22 @@ final class InputObjectTest extends FieldDefinitionTest
             """User errors for UpdateBook"""
             type UpdateBookResult {
               """The payload, if any"""
-              result: Boolean
+              _result: Boolean
             
               """Whether all validation passed. True for yes, false for no."""
-              valid: Boolean!
+              _valid: Boolean!
             
-              """Validation errors for UpdateBook"""
-              suberrors: UpdateBook_FieldErrors
+              """Error for book"""
+              book: UpdateBook_BookError
             }
             
             """User errors for Book"""
             type UpdateBook_BookError {
-              """A numeric error code. 0 on success, non-zero on failure."""
-              code: Int
+              """Error for title"""
+              title: UpdateBook_Book_TitleError
             
-              """An error message."""
-              msg: String
-            
-              """Validation errors for Book"""
-              suberrors: UpdateBook_Book_FieldErrors
+              """Error for authorId"""
+              authorId: UpdateBook_Book_AuthorIdError
             }
             
             """User errors for AuthorId"""
@@ -106,15 +103,6 @@ final class InputObjectTest extends FieldDefinitionTest
               unknownAuthor
             }
             
-            """User Error"""
-            type UpdateBook_Book_FieldErrors {
-              """Error for title"""
-              title: UpdateBook_Book_TitleError
-            
-              """Error for authorId"""
-              authorId: UpdateBook_Book_AuthorIdError
-            }
-            
             """User errors for Title"""
             type UpdateBook_Book_TitleError {
               """A numeric error code. 0 on success, non-zero on failure."""
@@ -122,12 +110,6 @@ final class InputObjectTest extends FieldDefinitionTest
             
               """An error message."""
               msg: String
-            }
-            
-            """User Error"""
-            type UpdateBook_FieldErrors {
-              """Error for book"""
-              book: UpdateBook_BookError
             }
             
             input book {

--- a/tests/Type/UserErrorsType/InputObjectTest.php
+++ b/tests/Type/UserErrorsType/InputObjectTest.php
@@ -186,4 +186,51 @@ final class InputObjectTest extends FieldDefinitionTest
             ]
         );
     }
+
+    public function testValidateOnDeeplyNestedField(): void
+    {
+        $this->_checkTypes(
+            UserErrorsType::create([
+                'type' => new InputObjectType([
+                    'name' => 'book',
+                    'fields' => [
+                        'author' => [
+                            'type' => new InputObjectType([
+                                'name' => 'address',
+                                'fields' => [
+                                    'zip' => [
+                                        'validate' => static function() {},
+                                        'type' => Type::string()
+                                    ]
+                                ]
+                            ])
+                        ]
+                    ],
+                ]),
+            ], ['updateBook']),
+            [
+              'UpdateBookError' => '
+                    type UpdateBookError {
+                      """Error for author"""
+                      author: UpdateBook_AuthorError
+                    }
+              ',
+              'UpdateBook_AuthorError' => '
+                    type UpdateBook_AuthorError {
+                      """Error for zip"""
+                      zip: UpdateBook_Author_ZipError
+                    }
+              ',
+              'UpdateBook_Author_ZipError' => '
+                    type UpdateBook_Author_ZipError {
+                      """A numeric error code. 0 on success, non-zero on failure."""
+                      code: Int
+                    
+                      """An error message."""
+                      msg: String
+                    }
+              ',
+            ]
+        );
+    }
 }

--- a/tests/Type/UserErrorsType/ListOfTest.php
+++ b/tests/Type/UserErrorsType/ListOfTest.php
@@ -219,4 +219,72 @@ final class ListOfTest extends FieldDefinitionTest
             ]
         );
     }
+
+    public function testValidateOnDeeplyNestedField(): void
+    {
+        $this->_checkTypes(
+            UserErrorsType::create([
+                'type' => Type::listOf(new InputObjectType([
+                    'name' => 'book',
+                    'fields' => [
+                        'author' => [
+                            'type' => Type::listOf(new InputObjectType([
+                                'name' => 'address',
+                                'fields' => [
+                                    'zip' => [
+                                        'validate' => static function() {},
+                                        'type' => Type::listOf(Type::string())
+                                    ]
+                                ]
+                            ]))
+                        ]
+                    ],
+                ])),
+            ], ['updateBook'], true),
+            [
+              'UpdateBookError' => '
+                    type UpdateBookError {
+                      """Validation errors for UpdateBook"""
+                      suberrors: UpdateBook_FieldErrors
+                    
+                      """A path describing this items\'s location in the nested array"""
+                      path: [Int]
+                    }
+              ',
+              'UpdateBook_FieldErrors' => '
+                    type UpdateBook_FieldErrors {
+                      """Error for author"""
+                      author: [UpdateBook_AuthorError]
+                    }
+              ',
+              'UpdateBook_AuthorError' => '
+                    type UpdateBook_AuthorError {
+                      """Validation errors for Author"""
+                      suberrors: UpdateBook_Author_FieldErrors
+                    
+                      """A path describing this items\'s location in the nested array"""
+                      path: [Int]
+                    }
+              ',
+              'UpdateBook_Author_FieldErrors' => '
+                    type UpdateBook_Author_FieldErrors {
+                      """Error for zip"""
+                      zip: [UpdateBook_Author_ZipError]
+                    }
+              ',
+              'UpdateBook_Author_ZipError' => '
+                    type UpdateBook_Author_ZipError {
+                      """A numeric error code. 0 on success, non-zero on failure."""
+                      code: Int
+                    
+                      """An error message."""
+                      msg: String
+                    
+                      """A path describing this items\'s location in the nested array"""
+                      path: [Int]
+                    }
+              ',
+            ]
+        );
+    }
 }

--- a/tests/Type/UserErrorsType/ListOfTest.php
+++ b/tests/Type/UserErrorsType/ListOfTest.php
@@ -69,12 +69,6 @@ final class ListOfTest extends FieldDefinitionTest
               """Whether all validation passed. True for yes, false for no."""
               valid: Boolean!
             
-              """Validation errors for UpdateAddressBook"""
-              suberrors: UpdateAddressBook_FieldErrors
-            }
-            
-            """User Error"""
-            type UpdateAddressBook_FieldErrors {
               """Error for phoneNumbers"""
               phoneNumbers: [UpdateAddressBook_PhoneNumbersError]
             }
@@ -147,8 +141,8 @@ final class ListOfTest extends FieldDefinitionTest
               """Whether all validation passed. True for yes, false for no."""
               valid: Boolean!
             
-              """Validation errors for UpdateAddressBook"""
-              suberrors: UpdateAddressBook_FieldErrors
+              """Error for addresses"""
+              addresses: [UpdateAddressBook_AddressesError]
             }
             
             """User errors for Addresses"""
@@ -167,13 +161,7 @@ final class ListOfTest extends FieldDefinitionTest
             enum UpdateAddressBook_AddressesErrorCode {
               notEnoughData
             }
-            
-            """User Error"""
-            type UpdateAddressBook_FieldErrors {
-              """Error for addresses"""
-              addresses: [UpdateAddressBook_AddressesError]
-            }
-            
+
         ');
     }
 
@@ -241,8 +229,8 @@ final class ListOfTest extends FieldDefinitionTest
               """Whether all validation passed. True for yes, false for no."""
               valid: Boolean!
             
-              """Validation errors for UpdateAddressBook"""
-              suberrors: UpdateAddressBook_FieldErrors
+              """Error for addresses"""
+              addresses: [UpdateAddressBook_AddressesError]
             }
             
             """User errors for Addresses"""
@@ -301,12 +289,6 @@ final class ListOfTest extends FieldDefinitionTest
             enum UpdateAddressBook_Addresses_ZipErrorCode {
               invalidZip
               tooFarAway
-            }
-            
-            """User Error"""
-            type UpdateAddressBook_FieldErrors {
-              """Error for addresses"""
-              addresses: [UpdateAddressBook_AddressesError]
             }
 
         ');

--- a/tests/Type/UserErrorsType/ListOfTest.php
+++ b/tests/Type/UserErrorsType/ListOfTest.php
@@ -36,307 +36,187 @@ final class ListOfTest extends FieldDefinitionTest
         '), SchemaPrinter::doPrint(new Schema(['query' => $type])));
     }
 
-    public function testListOfStringWithValidation(): void
+    public function testListOfStringWithValidationOnSelf(): void
     {
         $this->_checkTypes(UserErrorsType::create([
             'type' => Type::listOf(Type::string()),
             'errorCodes' => ['invalidPhoneNumber'],
             'validate' => static function (string $phoneNumber) {}
-            ], ['phoneNumber']),
-            []);
-    }
-
-    public function testListOfInputObjectWithValidation(): void
-    {
-        $this->_checkSchema(new ValidatedFieldDefinition([
-            'type' => Type::boolean(),
-            'name' => 'updateAddressBook',
-            'args' => [
-                'addresses' => [
-                    'type' => Type::listOf(new InputObjectType([
-                        'name' => 'Address',
-                        'fields' => [
-                            'city' => [
-                                'type' => Type::string()
-                            ],
-                            'zip' => [
-                                'type' => Type::int()
-                            ]
-                        ]
-                    ])),
-                    'errorCodes' => ['notEnoughData'],
-                    'validate' => static function (array $address) {
-                        if (empty($address['city'] && $address['zip'])) {
-                            return ['notEnoughData', 'You must a city or a zip code'];
-                        }
-                        return 0;
+            ], ['phoneNumber'], true),
+            [
+                'PhoneNumberError' => '
+                    type PhoneNumberError {
+                      """An error code"""
+                      code: PhoneNumberErrorCode
+                    
+                      """A natural language description of the issue"""
+                      msg: String
+                    
+                      """A path describing this items\'s location in the nested array"""
+                      path: [Int]
                     }
-                ],
-            ],
-            'resolve' => static function (array $data) : bool {
-                return !empty($data);
-            },
-        ]),'
-            input Address {
-              city: String
-              zip: Int
-            }
-            
-            type Mutation {
-              updateAddressBook(addresses: [Address]): UpdateAddressBookResult
-            }
-            
-            """User errors for UpdateAddressBook"""
-            type UpdateAddressBookResult {
-              """The payload, if any"""
-              result: Boolean
-            
-              """Whether all validation passed. True for yes, false for no."""
-              valid: Boolean!
-            
-              """Validation errors for UpdateAddressBook"""
-              suberrors: UpdateAddressBook_FieldErrors
-            }
-            
-            """User errors for Addresses"""
-            type UpdateAddressBook_AddressesError {
-              """An error code"""
-              code: UpdateAddressBook_AddressesErrorCode
-            
-              """A natural language description of the issue"""
-              msg: String
-            
-              """A path describing this items\'s location in the nested array"""
-              path: [Int]
-            }
-            
-            """Error code"""
-            enum UpdateAddressBook_AddressesErrorCode {
-              notEnoughData
-            }
-            
-            """User Error"""
-            type UpdateAddressBook_FieldErrors {
-              """Error for addresses"""
-              addresses: [UpdateAddressBook_AddressesError]
-            }
-
-        ');
-    }
-
-    public function testListOfInputObjectWithValidationAndSubvalidation(): void
-    {
-        $this->_checkSchema(new ValidatedFieldDefinition([
-            'type' => Type::boolean(),
-            'name' => 'updateAddressBook',
-            'args' => [
-                'addresses' => [
-                    'type' => Type::listOf(new InputObjectType([
-                        'name' => 'Address',
-                        'fields' => [
-                            'city' => [
-                                'errorCodes' => [
-                                    'invalidCity'
-                                ],
-                                'validate' => function($city) {
-                                    if ($city == "Toledo") {
-                                        return ['invalidCity', "Sorry, Toledo is not allowed"];
-                                    }
-                                    return 0;
-                                },
-                                'type' => Type::string()
-                            ],
-                            'zip' => [
-                                'errorCodes' => ['invalidZip', 'tooFarAway' ],
-                                'validate' => function($zip) {
-                                    if(!is_numeric($zip)) {
-                                        return ["invalidZip", "Invalid zip format; should be numeric"];
-                                    }
-                                    return 0;
-                                },
-                                'type' => Type::int()
-                            ]
-                        ]
-                    ])),
-                    'errorCodes' => ['notEnoughData'],
-                    'validate' => static function (array $address) {
-                        if (empty($address['city'] && $address['zip'])) {
-                            return ['notEnoughData', 'You must specify a city or a zip code'];
-                        }
-                        return 0;
-                    }
-                ],
-            ],
-            'resolve' => static function (array $data) : bool {
-                return !empty($data);
-            },
-        ]),'
-            input Address {
-              city: String
-              zip: Int
-            }
-            
-            type Mutation {
-              updateAddressBook(addresses: [Address]): UpdateAddressBookResult
-            }
-            
-            """User errors for UpdateAddressBook"""
-            type UpdateAddressBookResult {
-              """The payload, if any"""
-              result: Boolean
-            
-              """Whether all validation passed. True for yes, false for no."""
-              valid: Boolean!
-            
-              """Validation errors for UpdateAddressBook"""
-              suberrors: UpdateAddressBook_FieldErrors
-            }
-            
-            """User errors for Addresses"""
-            type UpdateAddressBook_AddressesError {
-              """An error code"""
-              code: UpdateAddressBook_AddressesErrorCode
-            
-              """A natural language description of the issue"""
-              msg: String
-            
-              """Validation errors for Addresses"""
-              suberrors: UpdateAddressBook_Addresses_FieldErrors
-            
-              """A path describing this items\'s location in the nested array"""
-              path: [Int]
-            }
-            
-            """Error code"""
-            enum UpdateAddressBook_AddressesErrorCode {
-              notEnoughData
-            }
-            
-            """User errors for City"""
-            type UpdateAddressBook_Addresses_CityError {
-              """An error code"""
-              code: UpdateAddressBook_Addresses_CityErrorCode
-            
-              """A natural language description of the issue"""
-              msg: String
-            }
-            
-            """Error code"""
-            enum UpdateAddressBook_Addresses_CityErrorCode {
-              invalidCity
-            }
-            
-            """User Error"""
-            type UpdateAddressBook_Addresses_FieldErrors {
-              """Error for city"""
-              city: UpdateAddressBook_Addresses_CityError
-            
-              """Error for zip"""
-              zip: UpdateAddressBook_Addresses_ZipError
-            }
-            
-            """User errors for Zip"""
-            type UpdateAddressBook_Addresses_ZipError {
-              """An error code"""
-              code: UpdateAddressBook_Addresses_ZipErrorCode
-            
-              """A natural language description of the issue"""
-              msg: String
-            }
-            
-            """Error code"""
-            enum UpdateAddressBook_Addresses_ZipErrorCode {
-              invalidZip
-              tooFarAway
-            }
-            
-            """User Error"""
-            type UpdateAddressBook_FieldErrors {
-              """Error for addresses"""
-              addresses: [UpdateAddressBook_AddressesError]
-            }
-
-        ');
-    }
-
-    public function testListOfListOfListOfScalarWithValidationOnSelfAndWrappedType(): void
-    {
-        $this->_checkSchema( new ValidatedFieldDefinition([
-            'type' => Type::boolean(),
-            'name' => 'updateAddressBook',
-            'errorCodes' => ['atLeastOnePhoneNumberRequired'],
-            'validate' => static function($data) {
-                if(empty($data['phoneNumbers'])) {
-                    return ['atLeastOnePhoneNumberRequired', "You must provide at least one phone number"];
-                }
-                return 0;
-            },
-            'args' => [
-                'phoneNumbers' => [
-                    'type' => Type::listOf(Type::listOf(Type::listOf(Type::id()))),
-                    'errorCodes'=> ['mustHaveSevenDigits'],
-                    'validate' => static function ($phoneNumber) {
-                        if(strlen($phoneNumber) != 7) {
-                            return ['mustHaveSevenDigits', "Phone numbers must have 7 digits"];
-                        }
-                        return 0;
-                    },
-                    'validateItem' => static function ($value) {
-                        return $value ? 0 : 1;
-                    }
-                 ]
+              '
             ]
-        ]), '
-            type Mutation {
-              updateAddressBook(phoneNumbers: [[[ID]]]): UpdateAddressBookResult
-            }
-            
-            """Error code"""
-            enum UpdateAddressBookErrorCode {
-              atLeastOnePhoneNumberRequired
-            }
-            
-            """User errors for UpdateAddressBook"""
-            type UpdateAddressBookResult {
-              """The payload, if any"""
-              result: Boolean
-            
-              """Whether all validation passed. True for yes, false for no."""
-              valid: Boolean!
-            
-              """An error code"""
-              code: UpdateAddressBookErrorCode
-            
-              """A natural language description of the issue"""
-              msg: String
-            
-              """Validation errors for UpdateAddressBook"""
-              suberrors: UpdateAddressBook_FieldErrors
-            }
-            
-            """User Error"""
-            type UpdateAddressBook_FieldErrors {
-              """Error for phoneNumbers"""
-              phoneNumbers: [UpdateAddressBook_PhoneNumbersError]
-            }
-            
-            """User errors for PhoneNumbers"""
-            type UpdateAddressBook_PhoneNumbersError {
-              """An error code"""
-              code: UpdateAddressBook_PhoneNumbersErrorCode
-            
-              """A natural language description of the issue"""
-              msg: String
-            
-              """A path describing this items\'s location in the nested array"""
-              path: [Int]
-            }
-            
-            """Error code"""
-            enum UpdateAddressBook_PhoneNumbersErrorCode {
-              mustHaveSevenDigits
-            }
+        );
+    }
 
-        ');
+    public function testListOfInputObjectWithValidationOnSelf(): void
+    {
+        $this->_checkTypes(UserErrorsType::create(
+            [
+                'type' => Type::listOf(new InputObjectType([
+                    'name' => 'Address',
+                    'fields' => [
+                        'city' => [
+                            'type' => Type::string()
+                        ],
+                        'zip' => [
+                            'type' => Type::int()
+                        ]
+                    ]
+                ])),
+                'errorCodes' => ['notEnoughData'],
+                'validate' => static function () {}
+            ],
+            ['address'],
+            true
+        ),
+            [
+                'AddressError' => '
+                    type AddressError {
+                      """An error code"""
+                      code: AddressErrorCode
+                    
+                      """A natural language description of the issue"""
+                      msg: String
+                    
+                      """A path describing this items\'s location in the nested array"""
+                      path: [Int]
+                    }
+                '
+            ]
+        );
+    }
+
+    public function testListOfInputObjectWithValidationOnFields(): void
+    {
+        $this->_checkTypes(UserErrorsType::create(
+            [
+                'type' => Type::listOf(new InputObjectType([
+                    'name' => 'Address',
+                    'fields' => [
+                        'city' => [
+                            'type' => Type::string(),
+                            'validate' => static function() {}
+                        ],
+                        'zip' => [
+                            'type' => Type::int(),
+                            'validate' => static function() {}
+                        ]
+                    ]
+                ]))
+            ],
+            ['address'],
+            true
+        ),
+            [
+              'AddressError' => '
+                    type AddressError {
+                      """Validation errors for Address"""
+                      suberrors: Address_FieldErrors
+                    
+                      """A path describing this items\'s location in the nested array"""
+                      path: [Int]
+                    }
+              ',
+              'Address_FieldErrors' => '
+                    type Address_FieldErrors {
+                      """Error for city"""
+                      city: Address_CityError
+                    
+                      """Error for zip"""
+                      zip: Address_ZipError
+                    }
+              '
+            ]
+        );
+    }
+
+    public function testListOfInputObjectWithValidationOnSelfAndFields(): void
+    {
+        $this->_checkTypes(UserErrorsType::create(
+            [
+                'validate' => static function() {},
+                'type' => Type::listOf(new InputObjectType([
+                    'name' => 'Address',
+                    'fields' => [
+                        'city' => [
+                            'type' => Type::string(),
+                            'validate' => static function() {}
+                        ],
+                        'zip' => [
+                            'type' => Type::int(),
+                            'validate' => static function() {}
+                        ]
+                    ]
+                ]))
+            ],
+            ['address'],
+            true
+        ),
+            [
+                'AddressError' => '
+                    type AddressError {
+                      """A numeric error code. 0 on success, non-zero on failure."""
+                      code: Int
+                    
+                      """An error message."""
+                      msg: String
+                    
+                      """Validation errors for Address"""
+                      suberrors: Address_FieldErrors
+                    
+                      """A path describing this items\'s location in the nested array"""
+                      path: [Int]
+                    }
+                ',
+                'Address_FieldErrors' => '
+                    type Address_FieldErrors {
+                      """Error for city"""
+                      city: Address_CityError
+                    
+                      """Error for zip"""
+                      zip: Address_ZipError
+                    }
+                '
+            ]
+        );
+    }
+
+    public function testListOfListOfListOfScalarWithValidation(): void
+    {
+        $this->_checkTypes(UserErrorsType::create(
+            [
+                'validate' => static function() {},
+                'type' => Type::listOf(Type::listOf(Type::listOf(Type::string())))
+            ],
+            ['ids'],
+            true
+        ),
+            [
+                'IdsError' => '
+                    type IdsError {
+                      """A numeric error code. 0 on success, non-zero on failure."""
+                      code: Int
+                    
+                      """An error message."""
+                      msg: String
+                    
+                      """A path describing this items\'s location in the nested array"""
+                      path: [Int]
+                    }
+                ',
+            ]
+        );
     }
 }

--- a/tests/Type/UserErrorsType/ListOfTest.php
+++ b/tests/Type/UserErrorsType/ListOfTest.php
@@ -69,6 +69,12 @@ final class ListOfTest extends FieldDefinitionTest
               """Whether all validation passed. True for yes, false for no."""
               valid: Boolean!
             
+              """Validation errors for UpdateAddressBook"""
+              suberrors: UpdateAddressBook_FieldErrors
+            }
+            
+            """User Error"""
+            type UpdateAddressBook_FieldErrors {
               """Error for phoneNumbers"""
               phoneNumbers: [UpdateAddressBook_PhoneNumbersError]
             }
@@ -141,8 +147,8 @@ final class ListOfTest extends FieldDefinitionTest
               """Whether all validation passed. True for yes, false for no."""
               valid: Boolean!
             
-              """Error for addresses"""
-              addresses: [UpdateAddressBook_AddressesError]
+              """Validation errors for UpdateAddressBook"""
+              suberrors: UpdateAddressBook_FieldErrors
             }
             
             """User errors for Addresses"""
@@ -160,6 +166,12 @@ final class ListOfTest extends FieldDefinitionTest
             """Error code"""
             enum UpdateAddressBook_AddressesErrorCode {
               notEnoughData
+            }
+            
+            """User Error"""
+            type UpdateAddressBook_FieldErrors {
+              """Error for addresses"""
+              addresses: [UpdateAddressBook_AddressesError]
             }
 
         ');
@@ -229,8 +241,8 @@ final class ListOfTest extends FieldDefinitionTest
               """Whether all validation passed. True for yes, false for no."""
               valid: Boolean!
             
-              """Error for addresses"""
-              addresses: [UpdateAddressBook_AddressesError]
+              """Validation errors for UpdateAddressBook"""
+              suberrors: UpdateAddressBook_FieldErrors
             }
             
             """User errors for Addresses"""
@@ -289,6 +301,12 @@ final class ListOfTest extends FieldDefinitionTest
             enum UpdateAddressBook_Addresses_ZipErrorCode {
               invalidZip
               tooFarAway
+            }
+            
+            """User Error"""
+            type UpdateAddressBook_FieldErrors {
+              """Error for addresses"""
+              addresses: [UpdateAddressBook_AddressesError]
             }
 
         ');

--- a/tests/Type/UserErrorsType/ListOfTest.php
+++ b/tests/Type/UserErrorsType/ListOfTest.php
@@ -38,65 +38,12 @@ final class ListOfTest extends FieldDefinitionTest
 
     public function testListOfStringWithValidation(): void
     {
-        $this->_checkSchema(new ValidatedFieldDefinition([
-            'type' => Type::boolean(),
-            'name' => 'updateAddressBook',
-            'args' => [
-                'phoneNumbers' => [
-                    'type' => Type::listOf(Type::string()),
-                    'errorCodes' => ['invalidPhoneNumber'],
-                    'validate' => static function (string $phoneNumber) {
-                        if (!is_numeric($phoneNumber)) {
-                            return ['invalidPhoneNumber', 'You must provide a valid phone number'];
-                        }
-                        return 0;
-                    }
-                ],
-            ],
-            'resolve' => static function (array $data) : bool {
-                return !empty($data);
-            },
-        ]),'
-            type Mutation {
-              updateAddressBook(phoneNumbers: [String]): UpdateAddressBookResult
-            }
-            
-            """User errors for UpdateAddressBook"""
-            type UpdateAddressBookResult {
-              """The payload, if any"""
-              result: Boolean
-            
-              """Whether all validation passed. True for yes, false for no."""
-              valid: Boolean!
-            
-              """Validation errors for UpdateAddressBook"""
-              suberrors: UpdateAddressBook_FieldErrors
-            }
-            
-            """User Error"""
-            type UpdateAddressBook_FieldErrors {
-              """Error for phoneNumbers"""
-              phoneNumbers: [UpdateAddressBook_PhoneNumbersError]
-            }
-            
-            """User errors for PhoneNumbers"""
-            type UpdateAddressBook_PhoneNumbersError {
-              """An error code"""
-              code: UpdateAddressBook_PhoneNumbersErrorCode
-            
-              """A natural language description of the issue"""
-              msg: String
-            
-              """A path describing this items\'s location in the nested array"""
-              path: [Int]
-            }
-            
-            """Error code"""
-            enum UpdateAddressBook_PhoneNumbersErrorCode {
-              invalidPhoneNumber
-            }
-
-        ');
+        $this->_checkTypes(UserErrorsType::create([
+            'type' => Type::listOf(Type::string()),
+            'errorCodes' => ['invalidPhoneNumber'],
+            'validate' => static function (string $phoneNumber) {}
+            ], ['phoneNumber']),
+            []);
     }
 
     public function testListOfInputObjectWithValidation(): void

--- a/tests/Type/UserErrorsType/NonNullTest.php
+++ b/tests/Type/UserErrorsType/NonNullTest.php
@@ -5,14 +5,9 @@ declare(strict_types=1);
 namespace GraphQL\Tests\Type\UserErrorsType;
 
 use GraphQL\Tests\Type\FieldDefinitionTest;
-use GraphQL\Tests\Utils;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\Type;
-use GraphQL\Type\Definition\UserErrorsType;
 use GraphQL\Type\Definition\ValidatedFieldDefinition;
-use GraphQL\Type\Schema;
-use GraphQL\Utils\SchemaPrinter;
-use PHPUnit\Framework\TestCase;
 
 final class NonNullTest extends FieldDefinitionTest
 {
@@ -45,8 +40,8 @@ final class NonNullTest extends FieldDefinitionTest
               """Whether all validation passed. True for yes, false for no."""
               valid: Boolean!
             
-              """Validation errors for DeleteAuthor"""
-              suberrors: DeleteAuthor_FieldErrors
+              """Error for authorId"""
+              authorId: DeleteAuthor_AuthorIdError
             }
             
             """User errors for AuthorId"""
@@ -61,12 +56,6 @@ final class NonNullTest extends FieldDefinitionTest
             """Error code"""
             enum DeleteAuthor_AuthorIdErrorCode {
               unknownAuthor
-            }
-            
-            """User Error"""
-            type DeleteAuthor_FieldErrors {
-              """Error for authorId"""
-              authorId: DeleteAuthor_AuthorIdError
             }
             
             type Mutation {
@@ -137,8 +126,8 @@ final class NonNullTest extends FieldDefinitionTest
               """Whether all validation passed. True for yes, false for no."""
               valid: Boolean!
             
-              """Validation errors for UpdateAuthor"""
-              suberrors: UpdateAuthor_FieldErrors
+              """Error for author"""
+              author: UpdateAuthor_AuthorError
             }
             
             """User errors for Author"""
@@ -183,12 +172,6 @@ final class NonNullTest extends FieldDefinitionTest
             
               """An error message."""
               msg: String
-            }
-            
-            """User Error"""
-            type UpdateAuthor_FieldErrors {
-              """Error for author"""
-              author: UpdateAuthor_AuthorError
             }
             
             input bookInput {

--- a/tests/Type/UserErrorsType/NonNullTest.php
+++ b/tests/Type/UserErrorsType/NonNullTest.php
@@ -40,8 +40,8 @@ final class NonNullTest extends FieldDefinitionTest
               """Whether all validation passed. True for yes, false for no."""
               valid: Boolean!
             
-              """Error for authorId"""
-              authorId: DeleteAuthor_AuthorIdError
+              """Validation errors for DeleteAuthor"""
+              suberrors: DeleteAuthor_FieldErrors
             }
             
             """User errors for AuthorId"""
@@ -58,6 +58,12 @@ final class NonNullTest extends FieldDefinitionTest
               unknownAuthor
             }
             
+            """User Error"""
+            type DeleteAuthor_FieldErrors {
+              """Error for authorId"""
+              authorId: DeleteAuthor_AuthorIdError
+            }
+            
             type Mutation {
               deleteAuthor(authorId: String!): DeleteAuthorResult
             }
@@ -67,7 +73,6 @@ final class NonNullTest extends FieldDefinitionTest
 
     public function testInputObjectWrappedType(): void
     {
-
         $this->_checkSchema(new ValidatedFieldDefinition([
             'type' => Type::boolean(),
             'name' => 'updateAuthor',
@@ -126,8 +131,8 @@ final class NonNullTest extends FieldDefinitionTest
               """Whether all validation passed. True for yes, false for no."""
               valid: Boolean!
             
-              """Error for author"""
-              author: UpdateAuthor_AuthorError
+              """Validation errors for UpdateAuthor"""
+              suberrors: UpdateAuthor_FieldErrors
             }
             
             """User errors for Author"""
@@ -172,6 +177,12 @@ final class NonNullTest extends FieldDefinitionTest
             
               """An error message."""
               msg: String
+            }
+            
+            """User Error"""
+            type UpdateAuthor_FieldErrors {
+              """Error for author"""
+              author: UpdateAuthor_AuthorError
             }
             
             input bookInput {

--- a/tests/Type/ValidatedFieldDefinition/GeneratedCodeTypeTest.php
+++ b/tests/Type/ValidatedFieldDefinition/GeneratedCodeTypeTest.php
@@ -126,7 +126,7 @@ final class GeneratedCodeTypeTest extends TestCase
         );
 
         static::assertEmpty($res->errors);
-        static::assertEquals($res->data['updateBook']['suberrors']['bookId']['code'], "invalidBookId");
-        static::assertEquals($res->data['updateBook']['suberrors']['bookId']['msg'], "Invalid Book Id");
+        static::assertEquals("invalidBookId", $res->data['updateBook']['suberrors']['bookId']['code']);
+        static::assertEquals("Invalid Book Id", $res->data['updateBook']['suberrors']['bookId']['msg']);
     }
 }

--- a/tests/Type/ValidatedFieldDefinition/InputObjectValidationTest.php
+++ b/tests/Type/ValidatedFieldDefinition/InputObjectValidationTest.php
@@ -119,10 +119,48 @@ final class InputObjectValidationTest extends FieldDefinitionTest
         );
     }
 
-    public function testValidationInputObjectSelfFail(): void
+    public function testInputObjectValidationOnParentAndFailField(): void
     {
-        $res = GraphQL::executeQuery(
-            $this->schema,
+        $this->_checkValidation(
+            new ValidatedFieldDefinition([
+                'name' => 'updateBook',
+                'type' => Type::boolean(),
+                'args' => [
+                    'bookAttributes' => [
+                        'validate' => static function($atts) {
+                            return 0;
+                        },
+                        'type' => new InputObjectType([
+                            'name' => 'BookAttributes',
+                            'fields' => [
+                                'title' => [
+                                    'type' => Type::string(),
+                                    'description' => 'Enter a book title, no more than 10 characters in length',
+                                    'validate' => static function (string $title) {
+                                        if (strlen($title) > 10) {
+                                            return [1, 'book title must be less than 10 characters'];
+                                        }
+                                        return 0;
+                                    },
+                                ],
+                                'author' => [
+                                    'type' => Type::id(),
+                                    'description' => 'Provide a valid author id',
+                                    'validate' => function (string $authorId) {
+                                        if (!isset($this->data['people'][$authorId])) {
+                                            return [1, 'We have no record of that author'];
+                                        }
+                                        return 0;
+                                    },
+                                ],
+                            ],
+                        ]),
+                    ],
+                ],
+                'resolve' => static function ($value): bool {
+                    return !$value;
+                },
+            ]),
             Utils::nowdoc('
                 mutation UpdateBook(
                         $bookAttributes: BookAttributes
@@ -133,8 +171,6 @@ final class InputObjectValidationTest extends FieldDefinitionTest
                         valid
                         suberrors {
                             bookAttributes {
-                                code
-                                msg
                                 suberrors {
                                     title {
                                         code
@@ -151,134 +187,36 @@ final class InputObjectValidationTest extends FieldDefinitionTest
                     }
                 }
             '),
-            [],
-            null,
             [
                 'bookAttributes' => [
-                    'title' => null,
-                    'author' => null,
+                    'title' => 'The Catcher in the Rye',
+                    'author' => 4,
                 ],
-            ]
-        );
-
-        static::assertEquals(
-            array(
+            ],
+            [
                 'valid' => false,
                 'suberrors' =>
                     [
                         'bookAttributes' =>
                             [
-                                'code' => 'titleOrIdRequired',
-                                'msg' => 'You must supply at least one of title or author',
-                                'suberrors' => NULL,
+                                'suberrors' => [
+                                    'title' =>
+                                        [
+                                            'code' => 1,
+                                            'msg' => 'book title must be less than 10 characters',
+                                        ],
+                                    'author' =>
+                                        [
+                                            'code' => 1,
+                                            'msg' => 'We have no record of that author',
+                                        ],
+                                    ]
                             ],
                     ],
                 'result' => null,
-            ),
-            $res->data['updateBook']
-        );
-
-        static::assertFalse($res->data['updateBook']['valid']);
-    }
-
-    public function testValidationSuccess(): void
-    {
-        $res = GraphQL::executeQuery(
-            $this->schema,
-            Utils::nowdoc('
-                mutation UpdateBook(
-                    $bookAttributes: BookAttributes
-                ) {
-                    updateBook (
-                        bookAttributes: $bookAttributes
-                    ) {
-                        valid
-                        suberrors {
-                            bookAttributes {
-                                suberrors {
-                                    title {
-                                        code
-                                        msg
-                                    }
-                                    author {
-                                        code
-                                        msg
-                                    }
-                                }
-                            }
-                        }
-                        result
-                    }
-                }
-            '),
-            [],
-            null,
-            [
-                'bookAttributes' => [
-                    'title' => 'Dogsbody',
-                    'author' => 3,
-                ],
             ]
         );
-
-        static::assertEmpty($res->errors);
-        static::assertEquals(
-            [
-                'valid' => true,
-                'suberrors' => null,
-                'result' => true,
-            ],
-            $res->data['updateBook']
-        );
-
-        static::assertTrue($res->data['updateBook']['valid']);
     }
 
-    public function testValidationEmptyInput(): void
-    {
-        $res = GraphQL::executeQuery(
-            $this->schema,
-            Utils::nowdoc('
-                mutation UpdateBook(
-                        $bookAttributes: BookAttributes
-                    ) {
-                    updateBook (
-                        bookAttributes: $bookAttributes
-                    ) {
-                        valid
-                        suberrors {
-                            bookAttributes {
-                                suberrors {
-                                    title {
-                                        code
-                                        msg
-                                    }
-                                    author {
-                                        code
-                                        msg
-                                    }
-                                }
-                            }
-                        }
-                        result
-                    }
-                }
-            '),
-            [],
-            null,
-            ['bookAttributes' => null]
-        );
 
-        static::assertEmpty($res->errors);
-        static::assertEquals(
-            [
-                'valid' => true,
-                'suberrors' => null,
-                'result' => true,
-            ],
-            $res->data['updateBook']
-        );
-
-        static::assertTrue($res->data['updateBook']['valid']);
-    }
 }

--- a/tests/Type/ValidatedFieldDefinition/ListOfInputObjectValidationTest.php
+++ b/tests/Type/ValidatedFieldDefinition/ListOfInputObjectValidationTest.php
@@ -19,9 +19,6 @@ use function strlen;
 
 final class ListOfInputObjectValidationTest extends FieldDefinitionTest
 {
-    /** @var InputObjectType */
-    protected $bookAttributesInputType;
-
     /** @var mixed[] */
     protected $data = [
         'people' => [
@@ -31,17 +28,13 @@ final class ListOfInputObjectValidationTest extends FieldDefinitionTest
         ],
     ];
 
-    /** @var ObjectType */
-    protected $query;
-
     /** @var Schema */
     protected $schema;
 
     protected function setUp(): void
     {
-        $this->query = new ObjectType(['name' => 'Query']);
         $this->schema = new Schema([
-            'query' => $this->query,
+            'query' => new ObjectType(['name' => 'Query']),
             'mutation' => new ObjectType([
                 'name' => 'Mutation',
                 'fields' => function () {

--- a/tests/Type/ValidatedFieldDefinition/ListOfInputObjectValidationTest.php
+++ b/tests/Type/ValidatedFieldDefinition/ListOfInputObjectValidationTest.php
@@ -87,7 +87,6 @@ final class ListOfInputObjectValidationTest extends TestCase
         ]);
 
         $this->query = new ObjectType(['name' => 'Query']);
-
         $this->schema = $this->_createSchema();
     }
 

--- a/tests/Type/ValidatedFieldDefinition/ListOfInputObjectValidationTest.php
+++ b/tests/Type/ValidatedFieldDefinition/ListOfInputObjectValidationTest.php
@@ -42,9 +42,6 @@ final class ListOfInputObjectValidationTest extends FieldDefinitionTest
                         'updateBooks' => new ValidatedFieldDefinition([
                             'name' => 'updateBooks',
                             'type' => Type::boolean(),
-                            'validate' => static function ($book) {
-                                return !empty($book['author']) || !empty($book['title']) ? 0: [1, 'You must set an author or a title'];
-                            },
                             'args' => [
                                 'bookAttributes' => [
                                     'type' => Type::listOf(new InputObjectType([
@@ -75,10 +72,7 @@ final class ListOfInputObjectValidationTest extends FieldDefinitionTest
                                                 },
                                             ],
                                         ],
-                                    ])),
-                                    'validate' => static function ($var) {
-                                        return $var ? 0: 1;
-                                    },
+                                    ]))
                                 ],
                             ],
                             'resolve' => static function ($value) : bool {
@@ -104,12 +98,14 @@ final class ListOfInputObjectValidationTest extends FieldDefinitionTest
                     ) {
                         valid
                         result
-                        code
-                        msg
                         suberrors {
                             bookAttributes {
-                                code
-                                msg
+                                suberrors {
+                                    title {
+                                        code
+                                        msg
+                                    }
+                                }
                                 path
                             }
                         }
@@ -135,13 +131,23 @@ final class ListOfInputObjectValidationTest extends FieldDefinitionTest
         static::assertEmpty($res->errors);
 
         static::assertEquals(
-            array (
+            [
                 'valid' => false,
                 'result' => null,
-                'code' => 1,
-                'msg' => 'You must set an author or a title',
-                'suberrors' => null,
-            ),
+                'suberrors' =>
+                    [
+                        'bookAttributes' =>
+                            [
+                                [
+                                    'suberrors' =>
+                                        [
+                                            'title' => null,
+                                        ],
+                                    'path' => [ 1 ],
+                                ],
+                            ],
+                    ],
+            ],
             $res->data['updateBooks']
         );
 

--- a/tests/Type/ValidatedFieldDefinition/ListOfScalarValidationTest.php
+++ b/tests/Type/ValidatedFieldDefinition/ListOfScalarValidationTest.php
@@ -26,9 +26,8 @@ final class ListOfScalarValidationTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->query  = new ObjectType(['name' => 'Query']);
         $this->schema = new Schema([
-            'query' => $this->query,
+            'query' => new ObjectType(['name' => 'Query']),
             'mutation' => new ObjectType([
                 'name' => 'Mutation',
                 'fields' => static function () {

--- a/tests/Type/ValidatedFieldDefinition/ListOfScalarValidationTest.php
+++ b/tests/Type/ValidatedFieldDefinition/ListOfScalarValidationTest.php
@@ -77,6 +77,7 @@ final class ListOfScalarValidationTest extends TestCase
                                 phoneNumbers {
                                     path
                                     code
+                                    msg
                                 }
                             }
                             result
@@ -102,15 +103,15 @@ final class ListOfScalarValidationTest extends TestCase
                     [
                         'phoneNumbers' =>
                             [
-                                0 =>
-                                    [
-                                        'path' =>
-                                            [
-                                                0,
-                                                1,
-                                            ],
-                                        'code' => 'invalidPhoneNumber',
-                                    ],
+                                [
+                                    'path' =>
+                                        [
+                                            0,
+                                            1,
+                                        ],
+                                    'code' => 'invalidPhoneNumber',
+                                    'msg' => 'That does not seem to be a valid phone number',
+                                ],
                             ],
                     ],
                 'result' => null,

--- a/tests/Utils.php
+++ b/tests/Utils.php
@@ -39,4 +39,32 @@ class Utils
 
         return implode("\n", $lines);
     }
+
+    // same as native var_export, but uses short array syntax
+    static function varExport($expression, bool $return = false) {
+        $export = var_export($expression, true);
+        $patterns = [
+            "/array \(/" => '[',
+            "/^([ ]*)\)(,?)$/m" => '$1]$2',
+            "/=>[ ]?\n[ ]+\[/" => '=> [',
+            "/([ ]*)(\'[^\']+\') => ([\[\'])/" => '$1$2 => $3',
+        ];
+        $export = preg_replace(array_keys($patterns), array_values($patterns), $export);
+        if ($return) {
+            return $export;
+        }
+
+        echo $export;
+    }
+
+    static function toNowDoc($str, $numSpaces=0) {
+        $lines = preg_split('/\\n/', $str);
+        for($i = 0; $i < count($lines); $i++) {
+            $lines[$i] = str_repeat(" ", $numSpaces) . $lines[$i];
+        }
+        array_unshift($lines, "");
+        $lines[] = "  ";
+        $res = implode($lines,  "\n");
+        return $res;
+    }
 }


### PR DESCRIPTION
Optimization:

Only add a `suberrors` field to a generated error type if any of the following are true:
 * its parent is a `ListOf` type 
 * it has a 'validate' callback
 * it's the root node (and therefor has `valid` and `result` fields that have nowhere else to go)

Also:
* can now configure the names of the `valid` and `result` fields
* fixed bug with validation of `listOf` wrapped types