### PR TITLE
don't early exit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "user errors"
   ],
   "require": {
+    "php": "^8",
     "ext-json": "*",
     "ext-mbstring": "*",
     "ext-intl": "*"

--- a/src/Type/Definition/ValidatedFieldDefinition.php
+++ b/src/Type/Definition/ValidatedFieldDefinition.php
@@ -101,24 +101,6 @@ class ValidatedFieldDefinition extends FieldDefinition
         ], [$name], false, \ucfirst($name) . 'Result');
     }
 
-    private function _noop(mixed $value): int
-    {
-        // this is just a no-op validation function to fallback to when no validation function is provided
-        return 0;
-    }
-
-    /**
-     * @param   mixed[] $arr
-     */
-    protected function _isAssoc(array $arr): bool
-    {
-        if ($arr === []) {
-            return false;
-        }
-
-        return \array_keys($arr) !== \range(0, \count($arr) - 1);
-    }
-
     /**
      * @param mixed[] $arg
      * @param mixed $value

--- a/src/Type/Definition/ValidatedFieldDefinition.php
+++ b/src/Type/Definition/ValidatedFieldDefinition.php
@@ -158,24 +158,26 @@ class ValidatedFieldDefinition extends FieldDefinition
     }
 
     /**
-     * @param array<string, mixed> $config
+     * @param   array<string, mixed> $config
      * @param   mixed[]  $value
+     * @param   array<mixed> $res
      * @param   Array<string|int> $path
      *
      * @throws  ValidateItemsError
      */
-    protected function _validateItems(array $config, array $value, array $path, callable $validate, &$res): void
+    protected function _validateListOfType(array $config, array $value, array &$res, array $path=[0]): void
     {
+        $validate = $config['validate'] ?? null;
         $wrappedType = $config['type']->getWrappedType();
         foreach ($value as $idx => $subValue) {
             if ($wrappedType instanceof ListOfType) {
                 $path[\count($path) - 1] = $idx;
                 $newPath = $path;
                 $newPath[] = 0;
-                $this->_validateItems(["type"=>$wrappedType], $subValue, $newPath, $validate, $res);
+                $this->_validateListOfType(["type"=>$wrappedType, "validate" => $validate], $subValue, $res, $newPath );
             } else {
                 $path[\count($path) - 1] = $idx;
-                $err = $validate($subValue);
+                $err = $validate != null ? $validate($subValue): 0;
 
                 if (empty($err)) {
                     $wrappedType = $config['type']->getInnermostType();
@@ -197,15 +199,6 @@ class ValidatedFieldDefinition extends FieldDefinition
                 }
             }
         }
-    }
-
-    /**
-     * @param array<string, mixed> $config
-     * @param array<mixed> $res
-     */
-    protected function _validateListOfType(array $config, mixed $value, array &$res): void
-    {
-        $this->_validateItems($config, $value, [0], $config['validate'] ?? [$this, '_noop'], $res);
     }
 
     /**

--- a/tests/Type/ValidatedFieldDefinition/ListOfScalarValidationTest.php
+++ b/tests/Type/ValidatedFieldDefinition/ListOfScalarValidationTest.php
@@ -86,6 +86,7 @@ final class ListOfScalarValidationTest extends TestCase
                     [
                         '123-4567',
                         'xxx456-7890xxx',
+                        '555-whoops',
                     ],
                 ],
             ]
@@ -100,6 +101,14 @@ final class ListOfScalarValidationTest extends TestCase
                             'path' => [
                                 0,
                                 1,
+                            ],
+                            'code' => 'invalidPhoneNumber',
+                            'msg' => 'That does not seem to be a valid phone number',
+                        ],
+                        [
+                            'path' => [
+                                0,
+                                2,
                             ],
                             'code' => 'invalidPhoneNumber',
                             'msg' => 'That does not seem to be a valid phone number',


### PR DESCRIPTION
* Don't exit early when validating lists, or inputobject types with a self-validate (may need to add a flag to toggle this behavior if anybody complains).
* require PHP 8.0